### PR TITLE
commit/push できるように user を設定する

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,9 @@ runs:
       run: |
         set -xe
 
+        /usr/bin/git config --global user.name "${GITHUB_ACTOR}"
+        /usr/bin/git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+
         export __SHA=${{ inputs.sha || github.sha }}
         if [ ! -z "${{ inputs.branch_name }}" ]; then
           # Override sha value if branch_name is presented.


### PR DESCRIPTION
https://github.com/aiming/mq/pull/41677 とかで， actions 上から commit を push する事が今後増える想定されるので，その都度 author 設定するのは面倒なので，この compiste action を使う時点で設定するようにしておきます．
(多分公式の actions/checkout がそれをしてないのは， author を誰にするのかはその時々で変えれるようにしたいから?)