### PR TITLE
gc をオフにする

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,8 @@ runs:
       run: |
         set -xe
 
+        /usr/bin/git config --global gc.auto 0
+
         /usr/bin/git config --global user.name "${GITHUB_ACTOR}"
         /usr/bin/git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 


### PR DESCRIPTION
git gc をオフにしないと， CI 中の git command で gc しようとして重くなるのでオフにします


オリジナルの actions/checkout でも
https://github.com/actions/checkout/blob/e6d535c99c374d0c3f6d8cd8086a57b43c6c700a/src/git-source-provider.ts#L117
https://github.com/actions/checkout/blob/ec3a7ce113134d7a93b817d10a8272cb61118579/src/git-command-manager.ts#L357

特にフラグで制御してる訳でもなく(必要に応じてオンオフ切り替えれるようになってる)，固定でオフにしちゃってるので同じようにオフにします．