### PR TITLE
clone 後に別の branch を fetch できるようにする

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -60,6 +60,7 @@ runs:
         /usr/bin/git clone \
           --depth=1 \
           --reference-if-able=${{ inputs.reference_dir }} \
+          --no-single-branch \
           https://${{ inputs.github_actor }}:${{ inputs.github_token }}@github.com/${{ inputs.github_repository }}.git \
           ${{ inputs.checkout_dir }}
 


### PR DESCRIPTION
`git clone --depth=1` を指定すると， refspec の設定が
```ini
[remote "origin"]
    fetch = +refs/heads/main:refs/remotes/origin/main
```
みたいに， clone 時に指定した branch (未指定だと default branch)が固定されます．

この状態だと他の branch を checkout できなくなるので，もしその他の branch も使うような workflow を書きたい場合
```sh
git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
```
などと書き換えてから fetch する必要があります．

最初からこの設定はいってても大きな問題無い気はするので，設定いれちゃおうと思います

https://git-scm.com/docs/git-clone/ja#git-clone---depthltdepthgt
>**--depth \<depth\>**
>指定された数のコミットに切り詰められたヒストリーを持つ、「浅い」クローンを作成します。  `--no-single-branch` が指定されていない限り、 `--single-branch` を意味し、すべてのブランチの先端付近の履歴を取得します。サブモジュールを浅くクローンしたい場合には、 `--shallow-submodules` も指定してください。

https://git-scm.com/docs/git-clone/ja#git-clone---no-single-branch
>--[no-]single-branch
> `--branch` オプションで指定されたブランチ、またはリモートの `HEAD` が指し示すプライマリブランチの先端に至るまでの履歴のみをクローンします。 結果として得られるリポジトリをさらにフェッチすると、最初のクローン作成時にこのオプションが使用されたブランチのリモートトラッキングブランチのみが更新されます。 `--single-branch` クローンを作成したときに、リモートの HEAD がどのブランチも指していなかった場合は、リモートトラッキングブランチは作成されません。

depth 指定すると single-branch 指定されて，その結果 fetch オプションが `*` でなく `branch名` 指定されちゃうと．
