### PR TITLE
depthのdefault optionを""にして、git clone時に履歴を取得するようにした

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ inputs:
     required: true
   depth:
     description: 'git clone --depth={} option'
-    default: 1
+    default: ''
   ignore_dubious_ownership:
     description: 'Not used(deprecated)'
     default: true


### PR DESCRIPTION
depth指定なしのほうが早いため、default optionをdepth指定なしにした。

以下、憶測です。
- depth指定ありの場合、clone & fetchにより時間がかかってしまう。
- clone時にdepth指定なしのほうが（referenceある＆履歴すべて持ってくることにより)結果として早くなる。


