### PR TITLE
safe.directoryが複数同じものが登録されないようにした

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Check .gitconfig
+        run: |
+          if [ -f ~/.gitconfig ]; then
+            cat ~/.gitconfig
+          fi
+
       - name: Test default checkout
         uses: ./
         with:
@@ -100,3 +106,7 @@ jobs:
               exit 1
             fi
           popd
+
+      - name: Check .gitconfig
+        run: |
+          cat ~/.gitconfig

--- a/action.yml
+++ b/action.yml
@@ -67,7 +67,9 @@ runs:
           https://${{ inputs.github_actor }}:${{ inputs.github_token }}@github.com/${{ inputs.github_repository }}.git \
           ${{ inputs.checkout_dir }}
 
-        /usr/bin/git config --global --add safe.directory $(pwd)
+        if [ $(git  config --global --get-all safe.directory | grep -c "$(pwd)$") -eq 0 ]; then
+          /usr/bin/git config --global --add safe.directory $(pwd)
+        fi
 
         pushd ${{ inputs.checkout_dir }}
           if [ ! -z "$__BRANCH" ]; then


### PR DESCRIPTION
`git config --global --add` で safe.directory を登録すると同じディレクトリ名でも複数登録されてしまうので 
現在登録されているディレクトリ名をチェックしてから、 `git config --add....` をするようにした