### PR TITLE
try.shの場所をGITHUB_ACTION_PATHから取得

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,8 @@ runs:
       run: |
         set -x
 
-        source ./try.sh
+        echo $GITHUB_ACTION_PATH
+        source $GITHUB_ACTION_PATH/try.sh
 
         try_till_success curl -s 'https://github.com' > /dev/null
 


### PR DESCRIPTION
try.sh が current directoryにないので、$GITHUB_ACTION_PATH 以下で実行するようにした