### PR TITLE
リトライが正常に働かなかった現象の修正

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,3 +110,45 @@ jobs:
       - name: Check .gitconfig
         run: |
           cat ~/.gitconfig
+
+      - name: Test do not retry if command successfull
+        run: |
+          source try.sh
+
+          before=$(date +%s)
+          try_till_success ls
+          after=$(date +%s)
+
+          # コマンド呼び出しに時間がかかっているかでリトライ判定をしています
+          if [ $(expr $after - $before) -gt 1 ]; then
+            echo "::error:: 成功時にもリトライしています after = ${after}, before = ${before}"
+            exit 1
+          fi
+
+      - name: Test do retry if command failure
+        shell: bash +e -x {0}
+        run: |
+          source try.sh
+
+          before=$(date +%s)
+          try_till_success false
+          after=$(date +%s)
+
+          # コマンド呼び出しに時間がかかっているかでリトライ判定をしています
+          if [ $(expr $after - $before) -lt 2 ]; then
+            echo "::error:: 失敗時にリトライしていません after = ${after}, before = ${before}"
+            exit 1
+          fi
+
+      - name: Setup github.com connection
+        continue-on-error: true
+        run: |
+          # disable connect to github.com
+          echo '127.0.0.1 github.com' | sudo tee -a /etc/hosts
+
+      - name: Test retry checkout
+        continue-on-error: true
+        uses: ./
+        with:
+          depth: ''
+          checkout_dir: step7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,7 +120,7 @@ jobs:
           after=$(date +%s)
 
           # コマンド呼び出しに時間がかかっているかでリトライ判定をしています
-          if [ $(expr $after - $before) -gt 1 ]; then
+          if [ $(($after - $before)) -gt 1 ]; then
             echo "::error:: 成功時にもリトライしています after = ${after}, before = ${before}"
             exit 1
           fi

--- a/action.yml
+++ b/action.yml
@@ -40,8 +40,6 @@ runs:
     - shell: bash
       if: ${{ !env.ACT }}
       run: |
-        set -x
-
         echo $GITHUB_ACTION_PATH
         source $GITHUB_ACTION_PATH/try.sh
 

--- a/try.sh
+++ b/try.sh
@@ -16,8 +16,11 @@ function try_till_success {
 
   while [[ $attempt < $max_attempts ]]
   do
+    oldopt=$-
+    set +e
     "$@"
     exitCode=$?
+    set -$oldopt
 
     if [[ $exitCode == 0 ]]
     then


### PR DESCRIPTION
github actionsではデフォルトに `set -e` をしていて、shellscriptのエラー時に中断していた
そのため、`shell: bash +e -x {0}` を追加してエラー時にも継続するように修正した

また、リトライのテストも追加した