### PR TITLE
変数の空チェックが動かなくなっているのを修正

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,8 @@ runs:
         try_till_success curl -s 'https://github.com' > /dev/null
 
         export __SHA=${{ inputs.sha || github.sha }}
-        if [ ! -z "${{ inputs.branch_name }}" ]; then
+        BRANCH=${{ inputs.branch_name }}
+        if [ -n "$BRANCH" ]; then
           # Remove "refs/heads/" at head if exists it
           __BRANCH=${{ inputs.branch_name }}
           __BRANCH=${__BRANCH#refs/heads/}
@@ -59,8 +60,8 @@ runs:
           export GIT_LFS_SKIP_SMUDGE=1
         fi
 
-        DEPTH=''
-        if [ ! -z "${{ inputs.depth }}" ]; then
+        DEPTH=${{ inputs.depth }}
+        if [ -n "$DEPTH" ]; then
           DEPTH=--depth=${{ inputs.depth }}
         fi
 


### PR DESCRIPTION
外部の repository を指定する際に branch_name オプションを指定したところ動かず．
原因追っていったところ
```bash
if [ ! -z "${{ inputs.branch_name }}" ]; then
```
syntax error になってまたのでその修正です．

この箇所， `${{ inputs.branch_name }}` なんで変数…ぽいですけど，実際には actions 側で先に評価されて，
たとえば `branch_name: origin/develop` とかを渡していると，
```bash
if [ ! -z "origin/develop" ]; then
```

になってしまい，実質変数渡しでなくなるので， `-z` 判定で syntax error になってました．
あと否定になってたので `-n` オプションに変えてあります(ここは好みあるかもしれませんが)