### PR TITLE
`inputs.github_actor` の値により `lfs pull` できなくなる現象の修正

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -180,6 +180,26 @@ jobs:
             exit 1
           fi
 
+      - name: Test invalid github_actor value
+        uses: ./
+        with:
+          github_actor: 'github-actions%5Bbot%5D'
+          depth: ''
+          checkout_dir: step.actor_includes_invalid_character
+
+      - name: Have Endpoint= line on `git lfs env` outputs
+        run: |
+          pushd step.actor_includes_invalid_character
+            if [ $(git lfs env | grep 'Endpoint=' | grep 'info/lfs' | wc -l) == '1' ]; then
+              # Found a line
+              #   Endpoint=github.com/org/repo.git/info/lfs
+              exit 0
+            else
+              echo "::error:: git lfs envの値に `Endpoint=...info/lfs` の行が見つかりません"
+              exit 1
+            fi
+          popd
+
       - name: Setup github.com connection
         continue-on-error: true
         run: |

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,16 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - uses: actions/github-script@v7
+      id: script
+      with:
+        result-encoding: string
+        script: |
+          const actor = encodeURI('${{ inputs.github_actor }}')
+          const token = encodeURI('${{ inputs.github_token }}')
+          core.setOutput('actor', actor)
+          core.setOutput('token', token)
+
     - shell: bash
       if: ${{ !env.ACT }}
       run: |
@@ -50,6 +60,9 @@ runs:
 
         try_till_success curl -s 'https://github.com' > /dev/null
 
+        GITHUB_ACTOR='${{ steps.script.outputs.actor }}'
+        GITHUB_TOKEN='${{ steps.script.outputs.token }}'
+
         export __SHA=${{ inputs.sha || github.sha }}
         if [ ! -z "${{ inputs.branch_name }}" ]; then
           # Remove "refs/heads/" at head if exists it
@@ -57,7 +70,7 @@ runs:
           __BRANCH=${__BRANCH#refs/heads/}
 
           # Override sha value if branch_name is presented.
-          __SHA=$(try_till_success /usr/bin/git ls-remote https://${{ inputs.github_actor }}:${{ inputs.github_token }}@github.com/${{ inputs.github_repository }}.git | grep -E  "\srefs/heads/${__BRANCH}$" | cut -f 1 )
+          __SHA=$(try_till_success /usr/bin/git ls-remote https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${{ inputs.github_repository }}.git | grep -E  "\srefs/heads/${__BRANCH}$" | cut -f 1 )
         fi
 
         if ! ${{ inputs.fetch_lfs }}; then
@@ -77,7 +90,7 @@ runs:
           /usr/bin/git clone \
             $DEPTH \
             $REFERENCE_IF_ABLE \
-            https://${{ inputs.github_actor }}:${{ inputs.github_token }}@github.com/${{ inputs.github_repository }}.git \
+            https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${{ inputs.github_repository }}.git \
             ${{ inputs.checkout_dir }}
 
         CHECKOUT_FULL_PATH="$(pwd)/${{ inputs.checkout_dir }}"
@@ -98,8 +111,6 @@ runs:
 
           /usr/bin/git config --local user.name "${GITHUB_ACTOR}"
           /usr/bin/git config --local user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-          # workaround `git lfs pull` is failure
-          /usr/bin/git config lfs.url https://${{ inputs.github_actor }}:${{ inputs.github_token }}@github.com/${{ inputs.github_repository }}.git/info/lfs
         popd
 
         unset GIT_LFS_SKIP_SMUDGE


### PR DESCRIPTION
## 現象
- inputs.github_actor に `github_action[bot]` のような URL として正しくない文字があると、git lfs 時にうまく扱えなくなる

![image](https://github.com/aiming/checkout-with-reference-action/assets/108387548/320274dd-507f-49cb-b3e1-82ab58f5c8a9)

## 仮定
git lfs は repositoryのURLからEndpointを作成しているが、そこが設定されてないのでは？

## 調査
ということで、lfsのソースコードを見る
ここらへんで url.Parse() を呼んでいる
https://github.com/git-lfs/git-lfs/blob/main/git/git.go#L555-L568

憶測だけど、`[` `]` 入りの URL のパースに失敗して、Endpointが Unknownになっているのでは？
こんなの ⇛ `https://github-actions[bot]:test@github.com/org/repo.git`

url.Parse() をためした
![image](https://github.com/aiming/mq/assets/108387548/e17f11cd-62fc-4905-9b95-d13de59c60db)

## 確認したこと
`github_action[bot]` を `escapeURI` で escape してから、cloneしたところ lfs pull 時に正常にpullできた

